### PR TITLE
Added the ability to handle headers

### DIFF
--- a/Contract/HeaderableRequestInterface.php
+++ b/Contract/HeaderableRequestInterface.php
@@ -5,10 +5,10 @@ namespace CodingCulture\RequestResolverBundle\Contract;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * Interface ResolvableRequestInterface
+ * Interface HeaderableRequestInterface
  * @package App\CodingCulture\RequestResolverBundle\Contract
  */
-interface ResolvableRequestInterface
+interface HeaderableRequestInterface
 {
     /**
      * Should configure the passed OptionsResolver to match the expectations in structure and type of the
@@ -18,21 +18,14 @@ interface ResolvableRequestInterface
      *
      * @return OptionsResolver
      */
-    public function defineOptions(OptionsResolver $resolver): OptionsResolver;
+    public function defineHeaderOptions(OptionsResolver $resolver): OptionsResolver;
 
     /**
-     * Should store the validated request options for use.
+     * Should store the validated request headers for use.
      *
-     * @param array $options
+     * @param array $headers
      *
      * @return void
      */
-    public function setOptions(array $options): void;
-
-    /**
-     * Should define the Content-Type header the request should have.
-     *
-     * @return string
-     */
-    public function getContentType(): string;
+    public function setHeaders(array $headers): void;
 }

--- a/Request/GetResourceWithHeadersRequest.php
+++ b/Request/GetResourceWithHeadersRequest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace CodingCulture\RequestResolverBundle\Request;
+
+use CodingCulture\RequestResolverBundle\Contract\HeaderableRequestInterface;
+use CodingCulture\RequestResolverBundle\Contract\ResolvableRequestInterface;
+use CodingCulture\RequestResolverBundle\Resolver\RequestResolver;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Class GetResourceByIdRequest
+ * @package CodingCulture\RequestResolverBundle\Request
+ *
+ * This is a quite generic request, but also highlights the usage and requirements of this request resolver bundle.
+ * Once you have implemented all required methods from the ResolvableRequestInterface, you can then add the shorthand
+ * methods for fetching properties of the request, shown as ResolvableRequestInterface::getId.
+ *
+ * Using an ResolvableRequestInterface::getOptions() method should be considered faux pas, in that the aim of this
+ * bundle is to structure the request.
+ *
+ * If you want to do more in depth assertions -- like checking the database for a record matching the id -- you
+ * should look at implementing it on the service level. Request objects are meant purely for structure and type.
+ *
+ * ResolvableRequestInterface::setOptions() should always wire up the private $options.
+ *
+ * ResolvableRequestInterface::getContentType() should return which Content-Type is expected of the request.
+ */
+class GetResourceWithHeadersRequest implements ResolvableRequestInterface, HeaderableRequestInterface
+{
+    /**
+     * @var array
+     */
+    private $options = [];
+
+    /**
+     * @var array
+     */
+    private $headers = [];
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->options['id'];
+    }
+    
+    /**
+     * @param OptionsResolver $resolver
+     *
+     * @return OptionsResolver
+     */
+    public function defineOptions(OptionsResolver $resolver): OptionsResolver
+    {
+        $resolver
+            ->setRequired('id')
+            ->setAllowedTypes('id', ['int', 'string'])
+        ;
+
+        return $resolver;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return void
+     */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContentType(): string
+    {
+        return RequestResolver::CONTENT_TYPE_ALLOW_ALL;
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     *
+     * @return OptionsResolver
+     */
+    public function defineHeaderOptions(OptionsResolver $resolver): OptionsResolver
+    {
+        $resolver->setRequired('x-required-header');
+
+        return $resolver;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return void
+     */
+    public function setHeaders(array $headers): void
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRequiredHeader(): array
+    {
+        return $this->headers['x-required-header'];
+    }
+}

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -2,3 +2,4 @@ suites:
     request-resolver:
         spec_path: Tests/
         src_path: .
+verbose: true


### PR DESCRIPTION
While using the bundle we were unable to to get the headers from the request after it has been resolved.
I've added a seperate contact that can be added so that the headers are included in the request.
The headers can also be validated bij the OptionsResolver component. All the headers are defined by default, but extra validation can be added.