### PR TITLE
Fixing deprecation error

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,6 +15,8 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {


### PR DESCRIPTION
While running phpunit the following deprecation error is thrown. 

Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "CodingCulture\RequestResolverBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.

I've opted to add the @return annotation instead of the native return type in order to not break compatibility with the PHP 7.1 version stated in the readme.