### PR TITLE
Fix reference error in resolver after class name change

### DIFF
--- a/Resolver/RequestResolver.php
+++ b/Resolver/RequestResolver.php
@@ -2,6 +2,7 @@
 
 namespace CodingCulture\RequestResolverBundle\Resolver;
 
+
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -9,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use CodingCulture\RequestResolverBundle\Factory\OptionsFactory;
 use CodingCulture\RequestResolverBundle\Helper\TypeJuggleHelper;
-use CodingCulture\RequestResolverBundle\Contract\HeaderableRequestInterface;
+use CodingCulture\RequestResolverBundle\Contract\RequestWithHeadersInterface;
 use CodingCulture\RequestResolverBundle\Contract\ResolvableRequestInterface;
 use CodingCulture\RequestResolverBundle\Contract\ValidatableRequestInterface;
 
@@ -65,7 +66,7 @@ class RequestResolver
 
         $resolvable->setOptions($options);
 
-        if ($resolvable instanceof HeaderableRequestInterface) {
+        if ($resolvable instanceof RequestWithHeadersInterface) {
             $requestHeaders = $this->request->headers->all();
             
             $headerResolver = $resolvable->defineHeaderOptions(new OptionsResolver());

--- a/Resolver/RequestResolver.php
+++ b/Resolver/RequestResolver.php
@@ -2,7 +2,6 @@
 
 namespace CodingCulture\RequestResolverBundle\Resolver;
 
-
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RequestStack;


### PR DESCRIPTION
After renaming the contract, the resolver itself haden't been updated with this change