### PR TITLE
Fix depractation notice: Add future return type to CodingCultureRequestResolverExtension::load

### DIFF
--- a/DependencyInjection/CodingCultureRequestResolverExtension.php
+++ b/DependencyInjection/CodingCultureRequestResolverExtension.php
@@ -17,7 +17,7 @@ class CodingCultureRequestResolverExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
>Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "CodingCulture\RequestResolverBundle\DependencyInjection\CodingCultureRequestResolverExtension" now to avoid errors or add an explicit @return annotation to suppress this message.