### PR TITLE
[Bugfix] Leading zero truncation of phone numbers

### DIFF
--- a/Helper/TypeJuggleHelper.php
+++ b/Helper/TypeJuggleHelper.php
@@ -34,8 +34,9 @@ class TypeJuggleHelper
         }
 
         $hasDot = strpos((string) $value, '.') !== false;
+        $looksLikePhoneNumber = is_numeric($value) && str_starts_with($value, '0') && strlen($value) > 1;
 
-        if (!in_array(false, [is_numeric($value), !$hasDot], true)) {
+        if (!in_array(false, [is_numeric($value), !$hasDot, !$looksLikePhoneNumber], true)) {
             return (int) $value;
         }
 


### PR DESCRIPTION
The type juggler would identify belgian phone numbers without any spacing characters as integers, therefore removing the leading zero. By checking the format a bit more stringently, we avoid mutating the request information.